### PR TITLE
Improve README usage and release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,10 @@
 # PCL Android ARM64
 
-Prebuilt Point Cloud Library (PCL) binaries packaged as an Android AAR for `arm64-v8a`.
+Prebuilt [Point Cloud Library](https://pointclouds.org/) binaries for Android, packaged as an AAR with Prefab metadata.
 
-This project is meant for Android apps that already use CMake/NDK and want to use PCL without building PCL, Boost, Eigen, FLANN, and LZ4 from source.
+This repository is for Android apps that already use the NDK/CMake and want to use PCL without rebuilding PCL, Boost, Eigen, FLANN, and LZ4 from source.
 
-## What is included
-
-- Android AAR library module: `pclibrary`
-- Prefab metadata so native consumers can use `find_package(pclibrary REQUIRED CONFIG)`
-- Prebuilt native dependencies for `arm64-v8a`
-- Sample Android app that links against the published native target
-
-Supported ABI:
-
-```text
-arm64-v8a
-```
-
-Minimum Android API:
-
-```text
-minSdk 29
-```
-
-## Gradle dependency
+## Quick Start
 
 Add GitHub Packages to the consuming project's `settings.gradle`:
 
@@ -44,7 +25,7 @@ dependencyResolutionManagement {
 }
 ```
 
-Add the dependency to the Android app module:
+Add the package to the Android app module:
 
 ```groovy
 dependencies {
@@ -52,7 +33,7 @@ dependencies {
 }
 ```
 
-Enable Prefab and restrict the app to the supported ABI:
+Enable Prefab and restrict the app to `arm64-v8a`:
 
 ```groovy
 android {
@@ -61,6 +42,8 @@ android {
     }
 
     defaultConfig {
+        minSdk 29
+
         ndk {
             abiFilters "arm64-v8a"
         }
@@ -68,9 +51,7 @@ android {
 }
 ```
 
-## CMake usage
-
-In the consuming app's `CMakeLists.txt`:
+Link the native package from the app's `CMakeLists.txt`:
 
 ```cmake
 add_library(native-lib SHARED native-lib.cpp)
@@ -82,7 +63,7 @@ target_link_libraries(native-lib
         log)
 ```
 
-After this, native code can include PCL headers:
+Use PCL headers in C++:
 
 ```cpp
 #include <pcl/point_cloud.h>
@@ -90,55 +71,294 @@ After this, native code can include PCL headers:
 #include <pcl/filters/voxel_grid.h>
 ```
 
-## Local development
+## Package Coordinates
 
-Build the library and sample:
+| Field | Value |
+| --- | --- |
+| Maven repository | `https://maven.pkg.github.com/V-Serghei/pcl-binaries-android-armv8` |
+| Group ID | `io.github.vserghei` |
+| Artifact ID | `pcl-android-arm64` |
+| Current version | `1.0.1` |
+| Android ABI | `arm64-v8a` |
+| Minimum SDK | `29` |
+| Package format | Android AAR with Prefab |
 
-```powershell
-.\gradlew.bat clean :pclibrary:assembleRelease :sample:assembleDebug
+## Bundled Native Libraries
+
+| Component | Version | Notes |
+| --- | --- | --- |
+| PCL | `1.9.1` | Point Cloud Library static archives repackaged into `libpclibrary.so` |
+| Boost | `1.70` | Required by PCL |
+| Eigen | `3.3.7` | Header-only linear algebra dependency |
+| FLANN | `1.9.1` | Required by PCL search/kdtree functionality |
+| LZ4 | `1.9.1` | Compression dependency |
+| OpenMP runtime | NDK-provided | Linked because the bundled PCL archives were built with OpenMP |
+
+## Android Build Versions
+
+| Tool | Version |
+| --- | --- |
+| Android Gradle Plugin | `8.5.1` |
+| Gradle Wrapper | `8.10` |
+| Kotlin Gradle Plugin | `1.9.0` |
+| Compile SDK | `34` |
+| CMake | `3.22.1` |
+| Tested NDK | `26.1.10909125` |
+
+## Full Usage Example
+
+Minimal app module `build.gradle`:
+
+```groovy
+plugins {
+    id "com.android.application"
+}
+
+android {
+    namespace "com.example.pclapp"
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.example.pclapp"
+        minSdk 29
+        targetSdk 34
+
+        externalNativeBuild {
+            cmake {
+                cppFlags "-std=c++17"
+            }
+        }
+
+        ndk {
+            abiFilters "arm64-v8a"
+        }
+    }
+
+    buildFeatures {
+        prefab true
+    }
+
+    externalNativeBuild {
+        cmake {
+            path "src/main/cpp/CMakeLists.txt"
+            version "3.22.1"
+        }
+    }
+}
+
+dependencies {
+    implementation "io.github.vserghei:pcl-android-arm64:1.0.1"
+}
 ```
 
-Publish to GitHub Packages from a release workflow:
+Minimal app `CMakeLists.txt`:
 
-```powershell
-.\gradlew.bat :pclibrary:publish
+```cmake
+cmake_minimum_required(VERSION 3.22.1)
+
+project("pcl_app")
+
+add_library(native-lib SHARED native-lib.cpp)
+
+find_package(pclibrary REQUIRED CONFIG)
+
+target_link_libraries(native-lib
+        pclibrary::pclibrary
+        log)
 ```
 
-For local publishing tests:
+Minimal native smoke test:
 
-```powershell
-.\gradlew.bat :pclibrary:publishToMavenLocal
+```cpp
+#include <jni.h>
+#include <sstream>
+
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_example_pclapp_MainActivity_runPclSmokeTest(JNIEnv* env, jobject) {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>());
+    cloud->width = 8;
+    cloud->height = 1;
+    cloud->is_dense = true;
+    cloud->points.resize(cloud->width * cloud->height);
+
+    for (std::size_t i = 0; i < cloud->points.size(); ++i) {
+        cloud->points[i].x = static_cast<float>(i) * 0.01f;
+        cloud->points[i].y = static_cast<float>(i) * 0.02f;
+        cloud->points[i].z = static_cast<float>(i) * 0.03f;
+    }
+
+    pcl::PointCloud<pcl::PointXYZ> filtered;
+    pcl::VoxelGrid<pcl::PointXYZ> voxel_grid;
+    voxel_grid.setInputCloud(cloud);
+    voxel_grid.setLeafSize(0.03f, 0.03f, 0.03f);
+    voxel_grid.filter(filtered);
+
+    std::ostringstream message;
+    message << "Input points: " << cloud->size()
+            << ", filtered points: " << filtered.size();
+
+    return env->NewStringUTF(message.str().c_str());
+}
 ```
 
-## Sample app
+## Authentication For GitHub Packages
+
+GitHub Packages may require authentication even for public packages.
+
+For local development, put credentials in the consuming project's `~/.gradle/gradle.properties`:
+
+```properties
+gpr.user=YOUR_GITHUB_USERNAME
+gpr.key=YOUR_GITHUB_TOKEN_WITH_READ_PACKAGES
+```
+
+Do not commit tokens to this repository or to consuming apps.
+
+## Sample App
 
 The `sample` module demonstrates the intended integration:
 
-- `sample/build.gradle` enables Prefab and depends on `:pclibrary`
-- `sample/src/main/cpp/CMakeLists.txt` imports `pclibrary`
-- `sample/src/main/cpp/native-lib.cpp` creates a PCL point cloud and runs a voxel-grid filter
+| File | Purpose |
+| --- | --- |
+| `sample/build.gradle` | Enables Prefab, restricts ABI to `arm64-v8a`, and depends on `:pclibrary` |
+| `sample/src/main/cpp/CMakeLists.txt` | Imports the native package with `find_package(pclibrary REQUIRED CONFIG)` |
+| `sample/src/main/cpp/native-lib.cpp` | Creates a small point cloud and runs `pcl::VoxelGrid` |
 
-Run:
+Build the sample:
 
 ```powershell
 .\gradlew.bat :sample:assembleDebug
 ```
 
-## Publishing coordinates
+The generated APK is written to:
 
 ```text
-groupId:    io.github.vserghei
-artifactId: pcl-android-arm64
-version:    1.0.1
+sample/build/outputs/apk/debug/sample-debug.apk
 ```
+
+## Local Development
+
+Build the release AAR:
+
+```powershell
+.\gradlew.bat :pclibrary:assembleRelease
+```
+
+Build the sample app:
+
+```powershell
+.\gradlew.bat :sample:assembleDebug
+```
+
+Build both:
+
+```powershell
+.\gradlew.bat :pclibrary:assembleRelease :sample:assembleDebug
+```
+
+Test local Maven publishing:
+
+```powershell
+.\gradlew.bat :pclibrary:publishToMavenLocal
+```
+
+The release AAR is written to:
+
+```text
+pclibrary/build/outputs/aar/pclibrary-release.aar
+```
+
+## Release And Publishing
+
+The repository publishes to GitHub Packages from `.github/workflows/gradle-publish.yml`.
+
+Release flow:
+
+1. Update `VERSION_NAME` in `gradle.properties`.
+2. Commit and push the changes.
+3. Merge into `main`.
+4. Create a GitHub Release with a matching tag, for example `v1.0.1`.
+5. The `Gradle Package` workflow builds the library and sample.
+6. On release events, the workflow runs `:pclibrary:publish`.
+
+Expected published coordinate:
+
+```text
+io.github.vserghei:pcl-android-arm64:1.0.1
+```
+
+## What This Package Is Not
+
+This package is not a high-level Kotlin/Java PCL API.
+
+It is a native C++ package for Android/CMake consumers. The Kotlin `NativeLib` class in `pclibrary` is only a small native load-test bridge.
 
 ## Limitations
 
 - Only `arm64-v8a` is included.
-- Apps targeting other ABIs must either exclude them or provide matching PCL builds.
-- This package is intended for native C++/CMake consumers. The Kotlin `NativeLib` class is only a small load-test bridge, not a high-level PCL API.
-- GitHub Packages may require authentication even for public packages.
+- Apps targeting other ABIs must exclude them or provide matching PCL builds.
+- The bundled PCL build is `1.9.1`; newer PCL APIs may not be available.
+- The AAR is large because it packages PCL headers and a native shared library.
+- GitHub Packages access may require a GitHub token with `read:packages`.
 
-## Security note
+## Troubleshooting
 
-Do not put GitHub tokens in Gradle files. Use GitHub Actions `GITHUB_TOKEN`, repository secrets, environment variables, or local `gradle.properties`.
+### `find_package(pclibrary REQUIRED CONFIG)` fails
+
+Check that the app module has Prefab enabled:
+
+```groovy
+android {
+    buildFeatures {
+        prefab true
+    }
+}
+```
+
+### App builds for unsupported ABIs
+
+Restrict the ABI:
+
+```groovy
+android {
+    defaultConfig {
+        ndk {
+            abiFilters "arm64-v8a"
+        }
+    }
+}
+```
+
+### GitHub Packages returns 401 or 403
+
+Configure credentials in `~/.gradle/gradle.properties`:
+
+```properties
+gpr.user=YOUR_GITHUB_USERNAME
+gpr.key=YOUR_GITHUB_TOKEN_WITH_READ_PACKAGES
+```
+
+### `SDK location not found`
+
+Create a local, untracked `local.properties` file:
+
+```properties
+sdk.dir=C\:/Users/YOUR_USER/AppData/Local/Android/Sdk
+```
+
+### Windows reports locked build files
+
+Stop Gradle daemons and rebuild:
+
+```powershell
+.\gradlew.bat --stop
+.\gradlew.bat :sample:assembleDebug --no-daemon
+```
+
+## Security
+
+Never put GitHub tokens in Gradle files. Use GitHub Actions `GITHUB_TOKEN`, repository secrets, environment variables, or local `gradle.properties`.


### PR DESCRIPTION
This pull request significantly expands and restructures the `README.md` to provide a much more comprehensive and user-friendly guide for integrating the prebuilt Point Cloud Library (PCL) binaries for Android. The documentation now covers package coordinates, bundled dependencies, build and usage examples, authentication, sample app details, local development, release publishing, limitations, and troubleshooting.

Key improvements and additions:

**Documentation and Usage Instructions:**
* Rewrote and reorganized the introduction to clarify the package's purpose and usage context.
* Added detailed "Quick Start" and "Full Usage Example" sections, including minimal `build.gradle`, `CMakeLists.txt`, and C++ smoke test code for rapid integration.
* Provided explicit instructions for enabling Prefab, restricting ABI to `arm64-v8a`, and linking the native package.

**Package and Dependency Details:**
* Introduced tables listing package coordinates, bundled native libraries (with versions and notes), and Android build tool versions for transparency and reproducibility.

**Development, Publishing, and Troubleshooting:**
* Added sections on local development, publishing flow, and authentication for GitHub Packages, including security recommendations for handling tokens.
* Expanded and clarified limitations, and introduced a comprehensive troubleshooting guide for common integration issues.

**Sample App and Security:**
* Improved sample app documentation with a clear table of relevant files and their purposes.
* Strengthened security notes regarding handling of GitHub tokens.