### PR TITLE
Feature/enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,12 @@ Thumbs.db
 # Local tool downloads
 .tools/
 
+# Local Maven Central/GPG signing secrets
+*.asc
+*.gpg
+*.kbx
+signing.properties
+
 # Archives produced while preparing vendored native binaries
 pclibrary/src/main/cpp/pclib/jniLibs/arm64-v8a/pcl/lib/*.zip
 pclibrary/src/main/cpp/pclib/jniLibs/arm64-v8a/pcl/lib/*.a

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is for Android apps that already use the NDK/CMake and want to u
 
 ## Quick Start
 
-Add GitHub Packages to the consuming project's `settings.gradle`:
+After the package is published to Maven Central, add standard repositories to the consuming project's `settings.gradle`:
 
 ```groovy
 dependencyResolutionManagement {
@@ -14,13 +14,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven {
-            url = uri("https://maven.pkg.github.com/V-Serghei/pcl-binaries-android-armv8")
-            credentials {
-                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
-                password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
-            }
-        }
     }
 }
 ```
@@ -37,6 +30,8 @@ Enable Prefab and restrict the app to `arm64-v8a`:
 
 ```groovy
 android {
+    ndkVersion "26.1.10909125"
+
     buildFeatures {
         prefab true
     }
@@ -75,7 +70,8 @@ Use PCL headers in C++:
 
 | Field | Value |
 | --- | --- |
-| Maven repository | `https://maven.pkg.github.com/V-Serghei/pcl-binaries-android-armv8` |
+| Public Maven repository | `mavenCentral()` |
+| GitHub Packages repository | `https://maven.pkg.github.com/V-Serghei/pcl-binaries-android-armv8` |
 | Group ID | `io.github.vserghei` |
 | Artifact ID | `pcl-android-arm64` |
 | Current version | `1.0.2` |
@@ -103,7 +99,7 @@ Use PCL headers in C++:
 | Kotlin Gradle Plugin | `1.9.0` |
 | Compile SDK | `34` |
 | CMake | `3.22.1` |
-| Tested NDK | `26.1.10909125` |
+| Required NDK | `26.1.10909125` |
 
 ## Full Usage Example
 
@@ -117,6 +113,7 @@ plugins {
 android {
     namespace "com.example.pclapp"
     compileSdk 34
+    ndkVersion "26.1.10909125"
 
     defaultConfig {
         applicationId "com.example.pclapp"
@@ -150,6 +147,48 @@ dependencies {
     implementation "io.github.vserghei:pcl-android-arm64:1.0.2"
 }
 ```
+
+## Required NDK Version
+
+Install Android NDK `26.1.10909125` before building a consuming app.
+
+In Android Studio:
+
+```text
+Tools -> SDK Manager -> SDK Tools -> NDK (Side by side)
+```
+
+Enable **Show Package Details**, select:
+
+```text
+26.1.10909125
+```
+
+Then click **Apply**.
+
+Pin the same version in the Android module that uses this package:
+
+```groovy
+android {
+    ndkVersion "26.1.10909125"
+}
+```
+
+For example, in a consuming project with a `nativelib` module:
+
+```powershell
+.\gradlew.bat clean :nativelib:assembleDebug
+```
+
+This package was built and tested with NDK `26.1.10909125`. NDK 27 uses libc++ 18, where `std::binary_function` is fully removed. The bundled PCL/FLANN headers still reference `std::binary_function`, and NDK 26 still provides it in C++17 mode.
+
+If you see an error like this, the consuming app is likely building with NDK 27:
+
+```text
+flann/util/heap.h:108:35: error: no template named 'binary_function' in namespace 'std'
+```
+
+Use NDK `26.1.10909125` and rebuild.
 
 Minimal app `CMakeLists.txt`:
 
@@ -205,9 +244,30 @@ Java_com_example_pclapp_MainActivity_runPclSmokeTest(JNIEnv* env, jobject) {
 }
 ```
 
-## Authentication For GitHub Packages
+## GitHub Packages Fallback
 
 GitHub Packages may require authentication even for public packages.
+
+Use this repository only if the version you need is not published to Maven Central yet.
+
+Add GitHub Packages to the consuming project's `settings.gradle`:
+
+```groovy
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/V-Serghei/pcl-binaries-android-armv8")
+            credentials {
+                username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
+                password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}
+```
 
 For local development, put credentials in the consuming project's `~/.gradle/gradle.properties`:
 
@@ -291,6 +351,119 @@ Expected published coordinate:
 io.github.vserghei:pcl-android-arm64:1.0.2
 ```
 
+## Maven Central Manual Upload
+
+Maven Central is the recommended public distribution channel because consumers can use `mavenCentral()` without GitHub tokens.
+
+Central Portal does not accept a plain `.aar` file. The **Publish Component** dialog expects a signed Maven deployment bundle `.zip` that contains the AAR, POM, Gradle module metadata, sources jar, javadoc jar, checksums, and GPG signatures.
+
+### 1. Create A Signing Key
+
+Install GPG, then create a key:
+
+```powershell
+gpg --full-generate-key
+```
+
+Use:
+
+```text
+Key type: RSA and RSA
+Key size: 4096
+Expiration: your choice
+Name: V-Serghei
+Email: your email
+```
+
+List keys:
+
+```powershell
+gpg --list-secret-keys --keyid-format LONG
+```
+
+Export the private key as ASCII:
+
+```powershell
+gpg --armor --export-secret-keys YOUR_KEY_ID
+```
+
+Copy the full output, including:
+
+```text
+-----BEGIN PGP PRIVATE KEY BLOCK-----
+...
+-----END PGP PRIVATE KEY BLOCK-----
+```
+
+### 2. Configure Local Gradle Signing
+
+Add this to `~/.gradle/gradle.properties`:
+
+```properties
+signingInMemoryKeyFile=C:/Users/YOUR_USER/.gradle/pcl-central-signing-key.asc
+signingInMemoryKeyPassword=YOUR_GPG_KEY_PASSWORD
+```
+
+Save the exported private key to the file from `signingInMemoryKeyFile`. Do not commit this key file.
+
+You can also use an inline key instead of a file:
+
+```properties
+signingInMemoryKey=-----BEGIN PGP PRIVATE KEY BLOCK-----\n...\n-----END PGP PRIVATE KEY BLOCK-----
+signingInMemoryKeyPassword=YOUR_GPG_KEY_PASSWORD
+```
+
+Do not commit these properties.
+
+### 3. Build The Central Portal Bundle
+
+Run:
+
+```powershell
+.\gradlew.bat clean :pclibrary:mavenCentralBundle
+```
+
+The upload file will be created at:
+
+```text
+pclibrary/build/distributions/pcl-android-arm64-1.0.2-maven-central-bundle.zip
+```
+
+### 4. Upload In Central Portal
+
+In `central.sonatype.com/publishing`:
+
+1. Click **Publish Component**.
+2. Use deployment name:
+   ```text
+   pcl-android-arm64-1.0.2
+   ```
+3. Optional description:
+   ```text
+   PCL Android ARM64 AAR with Prefab metadata.
+   ```
+4. Click **Choose File**.
+5. Select:
+   ```text
+   pclibrary/build/distributions/pcl-android-arm64-1.0.2-maven-central-bundle.zip
+   ```
+6. Click **Publish Component**.
+7. Wait for validation.
+8. If validation passes, click **Publish** on the deployment card.
+
+After Maven Central sync completes, consumers can use:
+
+```groovy
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation "io.github.vserghei:pcl-android-arm64:1.0.2"
+}
+```
+
 ## What This Package Is Not
 
 This package is not a high-level Kotlin/Java PCL API.
@@ -332,6 +505,30 @@ android {
     }
 }
 ```
+
+### `std::binary_function` is missing in FLANN headers
+
+Pin the consuming Android module to NDK `26.1.10909125`:
+
+```groovy
+android {
+    ndkVersion "26.1.10909125"
+}
+```
+
+Then install that NDK through Android Studio:
+
+```text
+Tools -> SDK Manager -> SDK Tools -> NDK (Side by side) -> Show Package Details -> 26.1.10909125 -> Apply
+```
+
+Rebuild:
+
+```powershell
+.\gradlew.bat clean :nativelib:assembleDebug
+```
+
+NDK 27 uses libc++ 18, where `std::binary_function` is removed. The bundled PCL/FLANN version needs NDK 26 compatibility.
 
 ### GitHub Packages returns 401 or 403
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the package to the Android app module:
 
 ```groovy
 dependencies {
-    implementation "io.github.vserghei:pcl-android-arm64:1.0.2"
+    implementation "io.github.v-serghei:pcl-android-arm64:1.0.2"
 }
 ```
 
@@ -66,13 +66,32 @@ Use PCL headers in C++:
 #include <pcl/filters/voxel_grid.h>
 ```
 
+## Consumer Project Setup
+
+Use Maven Central as the default integration path. It is public and does not require GitHub credentials:
+
+```groovy
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation "io.github.v-serghei:pcl-android-arm64:1.0.2"
+}
+```
+
+GitHub Packages is only a fallback for versions that are not available on Maven Central yet. It can require a GitHub token with package read access, even when the repository and package are public.
+
+Consuming Android modules must also enable Prefab, use `arm64-v8a`, and pin NDK `26.1.10909125`.
+
 ## Package Coordinates
 
 | Field | Value |
 | --- | --- |
 | Public Maven repository | `mavenCentral()` |
 | GitHub Packages repository | `https://maven.pkg.github.com/V-Serghei/pcl-binaries-android-armv8` |
-| Group ID | `io.github.vserghei` |
+| Group ID | `io.github.v-serghei` |
 | Artifact ID | `pcl-android-arm64` |
 | Current version | `1.0.2` |
 | Android ABI | `arm64-v8a` |
@@ -144,7 +163,7 @@ android {
 }
 
 dependencies {
-    implementation "io.github.vserghei:pcl-android-arm64:1.0.2"
+    implementation "io.github.v-serghei:pcl-android-arm64:1.0.2"
 }
 ```
 
@@ -348,7 +367,7 @@ Release flow:
 Expected published coordinate:
 
 ```text
-io.github.vserghei:pcl-android-arm64:1.0.2
+io.github.v-serghei:pcl-android-arm64:1.0.2
 ```
 
 ## Maven Central Manual Upload
@@ -460,7 +479,7 @@ repositories {
 }
 
 dependencies {
-    implementation "io.github.vserghei:pcl-android-arm64:1.0.2"
+    implementation "io.github.v-serghei:pcl-android-arm64:1.0.2"
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,10 +22,9 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
-GROUP=io.github.vserghei
+GROUP=io.github.v-serghei
 VERSION_NAME=1.0.2
 POM_ARTIFACT_ID=pcl-android-arm64
 POM_NAME=PCL Android ARM64
 POM_DESCRIPTION=Prebuilt Point Cloud Library binaries packaged as an Android AAR with Prefab metadata for arm64-v8a.
 POM_URL=https://github.com/V-Serghei/pcl-binaries-android-armv8
-

--- a/pclibrary/build.gradle
+++ b/pclibrary/build.gradle
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.kotlin.android)
     id("maven-publish")
+    id("signing")
 }
 
 def nativeRoot = file('src/main/cpp/pclib/jniLibs/arm64-v8a')
@@ -95,9 +96,14 @@ tasks.register('preparePrefabHeaders', Sync) {
     into(prefabHeadersDir)
 }
 
+tasks.register('emptyJavadocJar', Jar) {
+    archiveClassifier = 'javadoc'
+}
+
 android {
     namespace 'io.github.vserghei.pcl'
     compileSdk 34
+    ndkVersion '26.1.10909125'
 
     defaultConfig {
         minSdk 29
@@ -175,12 +181,17 @@ publishing {
                 password = project.findProperty("gpr.key") ?: System.getenv("TOKEN")
             }
         }
+        maven {
+            name = "MavenCentralBundle"
+            url = layout.buildDirectory.dir("mavenCentralStaging").get().asFile.toURI()
+        }
     }
     publications {
         release(MavenPublication) {
             groupId = project.findProperty("GROUP")
             artifactId = project.findProperty("POM_ARTIFACT_ID")
             version = project.findProperty("VERSION_NAME")
+            artifact(tasks.named('emptyJavadocJar'))
 
             pom {
                 name = project.findProperty("POM_NAME")
@@ -211,6 +222,53 @@ publishing {
 afterEvaluate {
     publishing.publications.named("release", MavenPublication) {
         from components.release
+    }
+}
+
+signing {
+    def signingKey = project.findProperty("signingInMemoryKey") ?: System.getenv("SIGNING_KEY")
+    def signingKeyFile = project.findProperty("signingInMemoryKeyFile") ?: System.getenv("SIGNING_KEY_FILE")
+    def signingPassword = project.findProperty("signingInMemoryKeyPassword") ?: System.getenv("SIGNING_PASSWORD")
+
+    if (!signingKey && signingKeyFile) {
+        signingKey = file(signingKeyFile).text
+    }
+
+    required {
+        gradle.taskGraph.hasTask(":pclibrary:mavenCentralBundle") ||
+                gradle.taskGraph.hasTask(":pclibrary:publishReleasePublicationToMavenCentralBundleRepository")
+    }
+
+    if (signingKey) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+    }
+
+    sign publishing.publications.release
+}
+
+tasks.register('mavenCentralBundle', Zip) {
+    group = "publishing"
+    description = "Builds a signed Maven Central deployment bundle for manual upload in Central Portal."
+    dependsOn tasks.named('publishReleasePublicationToMavenCentralBundleRepository')
+
+    archiveFileName = "${project.findProperty("POM_ARTIFACT_ID")}-${project.findProperty("VERSION_NAME")}-maven-central-bundle.zip"
+    destinationDirectory = layout.buildDirectory.dir("distributions")
+    from(layout.buildDirectory.dir("mavenCentralStaging"))
+
+    doFirst {
+        def signingKey = project.findProperty("signingInMemoryKey") ?: System.getenv("SIGNING_KEY")
+        def signingKeyFile = project.findProperty("signingInMemoryKeyFile") ?: System.getenv("SIGNING_KEY_FILE")
+        if (!signingKey) {
+            signingKey = signingKeyFile ? file(signingKeyFile).text : null
+        }
+        if (!signingKey) {
+            throw new GradleException("Maven Central requires signed artifacts. Add signingInMemoryKeyFile and signingInMemoryKeyPassword to ~/.gradle/gradle.properties or set SIGNING_KEY_FILE and SIGNING_PASSWORD.")
+        }
+    }
+
+    doLast {
+        def bundleFile = archiveFile.get().asFile
+        println "Maven Central bundle created: ${bundleFile.absolutePath}"
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,6 +5,7 @@ plugins {
 android {
     namespace 'io.github.vserghei.pcl.sample'
     compileSdk 34
+    ndkVersion '26.1.10909125'
 
     defaultConfig {
         applicationId 'io.github.vserghei.pcl.sample'


### PR DESCRIPTION
This pull request updates the project to support publishing and consuming the Android AAR package via Maven Central as the primary distribution channel, while keeping GitHub Packages as a fallback. It also enforces and documents the use of NDK version 26.1.10909125 due to compatibility requirements. Major improvements include build script enhancements for Maven Central compatibility, updated documentation for consumers, and stricter enforcement of the required NDK version.

**Maven Central Publishing Support:**

- Added Maven Central as the default repository for consumers, updated all coordinates and documentation to use the new group ID (`io.github.v-serghei`), and provided detailed instructions for manual upload to Maven Central, including GPG signing steps. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-L23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R94) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L291-R483) [[4]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L25-L31)

- Enhanced `pclibrary/build.gradle` to support Maven Central requirements:
  - Added the `signing` plugin and configuration for in-memory GPG key signing.
  - Introduced an `emptyJavadocJar` task to generate a required javadoc artifact.
  - Added a `mavenCentralBundle` task to create a signed deployment ZIP for manual upload. [[1]](diffhunk://#diff-42ea3a4c53634039b26d13df47d767a33aa92717f99eefd5f301cbc104dbe8daR7) [[2]](diffhunk://#diff-42ea3a4c53634039b26d13df47d767a33aa92717f99eefd5f301cbc104dbe8daR99-R106) [[3]](diffhunk://#diff-42ea3a4c53634039b26d13df47d767a33aa92717f99eefd5f301cbc104dbe8daR184-R194) [[4]](diffhunk://#diff-42ea3a4c53634039b26d13df47d767a33aa92717f99eefd5f301cbc104dbe8daR228-R274)

**NDK Version Enforcement and Documentation:**

- Enforced `ndkVersion '26.1.10909125'` in both library and sample modules, and updated documentation to instruct consumers to use this version due to compatibility with PCL/FLANN headers. Provided troubleshooting steps for common build errors related to NDK version mismatches. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R34) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R121) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L150-R211) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R528-R551) [[6]](diffhunk://#diff-42ea3a4c53634039b26d13df47d767a33aa92717f99eefd5f301cbc104dbe8daR99-R106) [[7]](diffhunk://#diff-7ef1ba9002a5885610f61713986068bbc1fab28811b2a13e9e91b48f4673077aR8)

**Group and Artifact Coordinates Update:**

- Changed the group ID throughout the project and documentation from `io.github.vserghei` to `io.github.v-serghei` to match Maven Central requirements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R34) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R94) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L291-R483) [[4]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L25-L31)

**Improved Consumer Documentation:**

- Clarified the recommended use of Maven Central for public consumption, relegating GitHub Packages to fallback status. Provided step-by-step guides for both integration paths, including credential setup for GitHub Packages if needed. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L208-R290) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R94)

**Build and Publishing Workflow Enhancements:**

- Updated Gradle properties and build logic to ensure all published artifacts meet Maven Central requirements, including the presence of javadoc jars and signed artifacts. [[1]](diffhunk://#diff-42ea3a4c53634039b26d13df47d767a33aa92717f99eefd5f301cbc104dbe8daR184-R194) [[2]](diffhunk://#diff-42ea3a4c53634039b26d13df47d767a33aa92717f99eefd5f301cbc104dbe8daR228-R274) [[3]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L25-L31)

These changes make the package easier to consume for most Android developers, ensure compliance with Maven Central's publishing requirements, and prevent common build issues related to NDK version mismatches.